### PR TITLE
[NO MERGE] Heroku multi buildpacks and remove custom templates

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/peterkeen/heroku-buildpack-vendorbinaries.git
-https://github.com/heroku/heroku-buildpack-ruby.git

--- a/.vendor_urls
+++ b/.vendor_urls
@@ -1,3 +1,2 @@
 https://s3.amazonaws.com/docverter-binaries/calibre.tar.gz
 https://s3-eu-west-1.amazonaws.com/hubbado-heroku-binaries/pandoc-1.15.0.6.tar.gz
-https://s3.amazonaws.com/docverter-binaries/pandoc-templates-1.12.0.2.tar.gz

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Installing on Heroku is the easiest option. Simply clone the repo, create an app
 
     $ git clone https://github.com/Docverter/docverter.git
     $ cd docverter
-    $ heroku create --buildpack https://github.com/ddollar/heroku-buildpack-multi.git
+    $ heroku create
+    $ heroku buildpacks:add heroku/ruby
+    $ heroku buildpacks:add https://github.com/peterkeen/heroku-buildpack-vendorbinaries
     $ heroku config:add PATH=bin:/app/bin:/app/jruby/bin:/usr/bin:/bin:/app/calibre/bin
     $ heroku config:add LD_LIBRARY_PATH=/app/calibre/lib
     $ git push heroku master


### PR DESCRIPTION
This is the deploy branch as of September 26, 2016.
When https://github.com/Docverter/docverter/pull/46 and https://github.com/Docverter/docverter/pull/47 are merged, update master and deploy from it instead.